### PR TITLE
specified shell has been removed

### DIFF
--- a/packages/mookme/src/utils/run-step.ts
+++ b/packages/mookme/src/utils/run-step.ts
@@ -47,7 +47,7 @@ export function runStep(
     }
 
     const command = computeExecutedCommand(step.command, options.type, options.venvActivate);
-    const cp = exec(command.replace('{args}', `"${args.join(' ')}"`), { cwd: packagePath, shell: '/bin/bash' });
+    const cp = exec(command.replace('{args}', `"${args.join(' ')}"`), { cwd: packagePath });
 
     /* handle command outputs */
     let out = '';


### PR DESCRIPTION
If u execute mookme on windows then step execution does not work due to there is no `/bin/bash` shell on windows.

According to the NodeJS documentation if shell is not specified then `sh` will be used for UNIX and cmd for windows.